### PR TITLE
fix: trocando o Path dos arquivos na main.dart

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'services/local_storage_service.dart';
-import 'routes.dart';
+import 'package:bico_certo/services/local_storage_service.dart';
+import 'package:bico_certo/routes.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
Trocando o Path dos arquivos na main.dart.
- Utilizar:
import 'package:bico_certo/routes.dart';

- Ao invés de:
import 'routes.dart';

Usar caminho relativo pode causar errors.